### PR TITLE
Fix combine warning from fft, add options for background

### DIFF
--- a/Background/RunBackgroundScripts.py
+++ b/Background/RunBackgroundScripts.py
@@ -13,7 +13,8 @@ def get_options():
   # Take inputs from a config file
   parser.add_option('--inputConfig', dest='inputConfig', default='', help="Name of input config file (if specified will ignore other options)")
   parser.add_option('--mode', dest='mode', default='std', help="Which script to run. Options: ['fTestOnly','fTestParallel','bkgPlotsOnly']")
-  parser.add_option('--plotDiff', dest='plotDiff', action='store_true', help="Plot difference instead of ratio in background description plots")
+  parser.add_option('--unblind', dest='unblind', action='store_true', help="Run script without blinding window around the Higgs boson mass")
+  parser.add_option('--plotRatio', dest='plotRatio', action='store_true', help="Plot difference instead of ratio in background description plots")
   parser.add_option('--jobOpts', dest='jobOpts', default='', help="Additional options to add to job submission. For Condor separate individual options with a colon (specify all within quotes e.g. \"option_xyz = abc+option_123 = 456\")")
   parser.add_option('--printOnly', dest='printOnly', default=False, action="store_true", help="Dry run: print submission files only")
   return parser.parse_args()
@@ -48,7 +49,8 @@ if opt.inputConfig != '':
 
     # Options from command line
     options['mode']                    = opt.mode
-    options['plotDiff']                = opt.plotDiff
+    options['unblind']                 = opt.unblind
+    options['plotRatio']               = opt.plotRatio
     options['jobOpts']                 = opt.jobOpts
     options['printOnly']               = opt.printOnly
 

--- a/Background/RunBackgroundScripts.py
+++ b/Background/RunBackgroundScripts.py
@@ -13,7 +13,7 @@ def get_options():
   # Take inputs from a config file
   parser.add_option('--inputConfig', dest='inputConfig', default='', help="Name of input config file (if specified will ignore other options)")
   parser.add_option('--mode', dest='mode', default='std', help="Which script to run. Options: ['fTestOnly','fTestParallel','bkgPlotsOnly']")
-  parser.add_option('--runBlind', dest='runBlind', action='store_true', help="Run script without blinding window around the Higgs boson mass")
+  parser.add_option('--runBlind', dest='runBlind', action='store_true', help="Run script with a blinding window around the Higgs boson mass")
   parser.add_option('--plotRatio', dest='plotRatio', action='store_true', help="Plot difference instead of ratio in background description plots")
   parser.add_option('--jobOpts', dest='jobOpts', default='', help="Additional options to add to job submission. For Condor separate individual options with a colon (specify all within quotes e.g. \"option_xyz = abc+option_123 = 456\")")
   parser.add_option('--printOnly', dest='printOnly', default=False, action="store_true", help="Dry run: print submission files only")

--- a/Background/RunBackgroundScripts.py
+++ b/Background/RunBackgroundScripts.py
@@ -13,7 +13,7 @@ def get_options():
   # Take inputs from a config file
   parser.add_option('--inputConfig', dest='inputConfig', default='', help="Name of input config file (if specified will ignore other options)")
   parser.add_option('--mode', dest='mode', default='std', help="Which script to run. Options: ['fTestOnly','fTestParallel','bkgPlotsOnly']")
-  parser.add_option('--unblind', dest='unblind', action='store_true', help="Run script without blinding window around the Higgs boson mass")
+  parser.add_option('--runBlind', dest='runBlind', action='store_true', help="Run script without blinding window around the Higgs boson mass")
   parser.add_option('--plotRatio', dest='plotRatio', action='store_true', help="Plot difference instead of ratio in background description plots")
   parser.add_option('--jobOpts', dest='jobOpts', default='', help="Additional options to add to job submission. For Condor separate individual options with a colon (specify all within quotes e.g. \"option_xyz = abc+option_123 = 456\")")
   parser.add_option('--printOnly', dest='printOnly', default=False, action="store_true", help="Dry run: print submission files only")
@@ -49,7 +49,7 @@ if opt.inputConfig != '':
 
     # Options from command line
     options['mode']                    = opt.mode
-    options['unblind']                 = opt.unblind
+    options['runBlind']                 = opt.runBlind
     options['plotRatio']               = opt.plotRatio
     options['jobOpts']                 = opt.jobOpts
     options['printOnly']               = opt.printOnly

--- a/Background/runBackgroundScripts.sh
+++ b/Background/runBackgroundScripts.sh
@@ -15,7 +15,7 @@ BKGPLOTSONLY=0
 SEED=0
 INTLUMI=1
 ISDATA=0
-UNBLIND=0
+RUNBLIND=0
 PLOTRATIO=0
 BATCH=""
 QUEUE=""
@@ -41,7 +41,7 @@ echo "--seed) for pseudodata random number gen seed (default $SEED)"
 echo "--intLumi) specified in fb^-{1} (default $INTLUMI)) "
 echo "--year) dataset year (default $YEAR)) "
 echo "--isData) specified in fb^-{1} (default $DATA)) "
-echo "--unblind) specified in fb^-{1} (default $UNBLIND)) "
+echo "--runBlind) specified in fb^-{1} (default $RUNBLIND)) "
 echo "--plotRatio) to plot mc-data instead of ratio (default $PLOTRATIO)) "
 echo "--batch) which batch system to use (None (''),HTCONDOR,IC) (default '$BATCH')) "
 echo "--queue) queue to submit jobs to (specific to batch))"
@@ -52,7 +52,7 @@ echo "--queue) queue to submit jobs to (specific to batch))"
 
 
 # options may be followed by one colon to indicate they have a required argument
-if ! options=$(getopt -u -o hi:p:f: -l help,inputFile:,procs:,flashggCats:,ext:,catOffset:,fTestOnly,pseudoDataOnly,bkgPlotsOnly,pseudoDataDat:,sigFile:,seed:,intLumi:,year:,unblind,isData,plotRatio,batch:,queue: -- "$@")
+if ! options=$(getopt -u -o hi:p:f: -l help,inputFile:,procs:,flashggCats:,ext:,catOffset:,fTestOnly,pseudoDataOnly,bkgPlotsOnly,pseudoDataDat:,sigFile:,seed:,intLumi:,year:,runBlind,isData,plotRatio,batch:,queue: -- "$@")
 then
 # something went wrong, getopt will put out an error message for us
 exit 1
@@ -77,7 +77,7 @@ case $1 in
 --intLumi) INTLUMI=$2; shift;;
 --year) YEAR=$2; shift;;
 --isData) ISDATA=1;;
---unblind) UNBLIND=1;;
+--runBlind) RUNBLIND=1;;
 --plotRatio) PLOTRATIO=1;;
 --batch) BATCH=$2; shift;;
 --queue) QUEUE=$2; shift;;
@@ -153,8 +153,8 @@ echo "Running Background F-Test"
 echo "-->Create background model"
 echo "--------------------------------------"
 OPT=""
-if [ $UNBLIND == 1 ]; then
-  OPT+=" --unblind"
+if [ $RUNBLIND == 1 ]; then
+  OPT+=" --runBlind"
 fi
 if [ $PLOTRATIO == 1 ]; then
   OPT+=" --plotRatio"
@@ -184,8 +184,8 @@ echo "--------------------------------------"
 if [ "$SIGFILE" != "" ]; then
 SIG="-s $SIGFILE"
 fi
-if [ $UNBLIND == 1 ]; then
-OPT=" --unblind"
+if [ $RUNBLIND == 1 ]; then
+OPT=" --runBlind"
 fi
 echo "./scripts/subBkgPlots.py -b CMS-HGG_multipdf_$EXT.root -d $OUTDIR/bkgPlots$DATAEXT -S 13 --isMultiPdf --useBinnedData  --doBands --massStep 1 $SIG -L 100 -H 180 -f $CATS -l $CATS --intLumi $INTLUMI $OPT --batch $BATCH -q $QUEUE --year $YEAR"
 ./scripts/subBkgPlots.py -b CMS-HGG_multipdf_$EXT.root -d $OUTDIR/bkgPlots$DATAEXT -S 13 --isMultiPdf --useBinnedData  --doBands  --massStep 1 $SIG -L 100 -H 180 -f $CATS -l $CATS --intLumi $INTLUMI $OPT --batch $BATCH -q $QUEUE --year $YEAR

--- a/Background/runBackgroundScripts.sh
+++ b/Background/runBackgroundScripts.sh
@@ -16,7 +16,7 @@ SEED=0
 INTLUMI=1
 ISDATA=0
 UNBLIND=0
-PLOTDIFF=0
+PLOTRATIO=0
 BATCH=""
 QUEUE=""
 YEAR="2016"
@@ -42,7 +42,7 @@ echo "--intLumi) specified in fb^-{1} (default $INTLUMI)) "
 echo "--year) dataset year (default $YEAR)) "
 echo "--isData) specified in fb^-{1} (default $DATA)) "
 echo "--unblind) specified in fb^-{1} (default $UNBLIND)) "
-echo "--plotDiff) to plot mc-data instead of ratio (default $PLOTDIFF)) "
+echo "--plotRatio) to plot mc-data instead of ratio (default $PLOTRATIO)) "
 echo "--batch) which batch system to use (None (''),HTCONDOR,IC) (default '$BATCH')) "
 echo "--queue) queue to submit jobs to (specific to batch))"
 }
@@ -52,7 +52,7 @@ echo "--queue) queue to submit jobs to (specific to batch))"
 
 
 # options may be followed by one colon to indicate they have a required argument
-if ! options=$(getopt -u -o hi:p:f: -l help,inputFile:,procs:,flashggCats:,ext:,catOffset:,fTestOnly,pseudoDataOnly,bkgPlotsOnly,pseudoDataDat:,sigFile:,seed:,intLumi:,year:,unblind,isData,plotDiff,batch:,queue: -- "$@")
+if ! options=$(getopt -u -o hi:p:f: -l help,inputFile:,procs:,flashggCats:,ext:,catOffset:,fTestOnly,pseudoDataOnly,bkgPlotsOnly,pseudoDataDat:,sigFile:,seed:,intLumi:,year:,unblind,isData,plotRatio,batch:,queue: -- "$@")
 then
 # something went wrong, getopt will put out an error message for us
 exit 1
@@ -78,7 +78,7 @@ case $1 in
 --year) YEAR=$2; shift;;
 --isData) ISDATA=1;;
 --unblind) UNBLIND=1;;
---plotDiff) PLOTDIFF=1;;
+--plotRatio) PLOTRATIO=1;;
 --batch) BATCH=$2; shift;;
 --queue) QUEUE=$2; shift;;
 
@@ -156,8 +156,8 @@ OPT=""
 if [ $UNBLIND == 1 ]; then
   OPT+=" --unblind"
 fi
-if [ $PLOTDIFF == 1 ]; then
-  OPT+=" --plotDiff"
+if [ $PLOTRATIO == 1 ]; then
+  OPT+=" --plotRatio"
 fi
 if [ $ISDATA == 0 ]; then
   FILE=$OUTDIR/pseudoData/pseudoWS.root

--- a/Background/test/fTest.cpp
+++ b/Background/test/fTest.cpp
@@ -58,8 +58,8 @@ using namespace RooFit;
 using namespace boost;
 
 namespace po = program_options;
-int data_by_fit = 0;
-bool BLIND = false;
+bool data_by_fit = false;
+bool BLIND = true;
 bool runFtestCheckWithToys=false;
 int mgg_low = 500;
 int mgg_high = 1000;
@@ -190,6 +190,7 @@ double getProbabilityFtest(double chi2, int ndof, RooAbsPdf *pdfNull, RooAbsPdf 
 
   int npass =0; int nsuccesst =0;
   mass->setBins(nBinsForMass);
+  mass->setBins(10000,"cache");
 
   for (int itoy = 0 ; itoy < ntoys ; itoy++){
     params_null->assignValueOnly(preParams_null);
@@ -459,7 +460,7 @@ void plot(RooRealVar *mass, RooAbsPdf *pdf, RooDataSet *data, string name,vector
     double bkgval = nomBkgCurve->interpolate(meanMass);
     if (bkgval <= 0) continue;
 
-    if (data_by_fit==1){
+    if (data_by_fit==true){
     double rel_err_low = errlow / bkgval;
     double rel_err_high = errhi / bkgval;
 
@@ -494,7 +495,7 @@ void plot(RooRealVar *mass, RooAbsPdf *pdf, RooDataSet *data, string name,vector
 
   pad2->cd();
   TH1 *hdummy = new TH1D("hdummyweight", "", nBinsForPlot, mgg_low, mgg_high);
-  if (data_by_fit == 1) {
+  if (data_by_fit == true) {
       hdummy->GetYaxis()->SetTitle("data/(best fit)");
       hdummy->SetMaximum(1.05);
       hdummy->SetMinimum(0.95);                     
@@ -513,7 +514,7 @@ void plot(RooRealVar *mass, RooAbsPdf *pdf, RooDataSet *data, string name,vector
   hdummy->Draw("HIST");
   hdummy->GetYaxis()->SetNdivisions(808);
 
-  if (data_by_fit == 1) {
+  if (data_by_fit == true) {
       TLine *line3 = new TLine(mgg_low, 1., mgg_high, 1.);
    line3->SetLineColor(kBlue);
   line3->SetLineWidth(5);
@@ -644,7 +645,7 @@ void plot(RooRealVar *mass, RooMultiPdf *pdfs, RooCategory *catIndex, RooDataSet
   }
   double errhi = plotdata->GetErrorYhigh(ipoint);
   double errlow = plotdata->GetErrorYlow(ipoint);
-  if (data_by_fit == 1) {
+  if (data_by_fit == true) {
     double rel_err_low = errlow/bkgval; 
     double rel_err_high = errhi/bkgval;
     hdatasub->SetPoint(point,xtmp,ytmp/bkgval);
@@ -664,7 +665,7 @@ void plot(RooRealVar *mass, RooMultiPdf *pdfs, RooCategory *catIndex, RooDataSet
   //TH1 *hdummy = new TH1D("hdummyweight","",mgg_high-mgg_low,mgg_low,mgg_high);
   TH1 *hdummy = new TH1D("hdummyweight","",nBinsForPlot,mgg_low,mgg_high);
   
-  if (data_by_fit == 1) {
+  if (data_by_fit == true) {
       hdummy->GetYaxis()->SetTitle("data/(best fit)");
       hdummy->SetMaximum(1.05);
       hdummy->SetMinimum(0.95);
@@ -684,7 +685,7 @@ void plot(RooRealVar *mass, RooMultiPdf *pdfs, RooCategory *catIndex, RooDataSet
   hdummy->Draw("HIST");
   hdummy->GetYaxis()->SetNdivisions(808);
 
-    if (data_by_fit == 1) {
+    if (data_by_fit == true) {
       TLine *line3 = new TLine(mgg_low, 1., mgg_high, 1.);
    line3->SetLineColor(bestcol);
   line3->SetLineWidth(5);
@@ -926,6 +927,7 @@ desc.add_options()
   ("is2011",                                                                                  "Run 2011 config")
   ("is2012",                                                                                  "Run 2012 config")
   ("unblind",  									        "Dont blind plots")
+  ("plotRatio", po::bool_switch(&data_by_fit)->default_value(false), "Plot data / fit instead of data - fit")
   ("isFlashgg",  po::value<int>(&isFlashgg_)->default_value(1),  								    	        "Use Flashgg output ")
   ("isData",  po::value<bool>(&isData_)->default_value(0),  								    	        "Use Data not MC ")
   ("flashggCats,f", po::value<string>(&flashggCatsStr_)->default_value("UntaggedTag_0,UntaggedTag_1,UntaggedTag_2,UntaggedTag_3,UntaggedTag_4,VBFTag_0,VBFTag_1,VBFTag_2,TTHHadronicTag,TTHLeptonicTag,VHHadronicTag,VHTightTag,VHLooseTag,VHEtTag"),       "Flashgg category names to consider")
@@ -1103,7 +1105,8 @@ for (int cat=startingCategory; cat<ncats; cat++){
         exit(1);
   }
   if(mass) {
-        mass->setBins(nBinsForMass); 
+        mass->setBins(nBinsForMass);
+        mass->setBins(10000,"cache");
         std::cout << "[DEBUG] Using " << nBinsForMass << " bins for [" 
                 << mass->getMin() << ", " << mass->getMax() << "]" << std::endl;
   } else {
@@ -1410,6 +1413,8 @@ for (int cat=startingCategory; cat<ncats; cat++){
     std::cout << "[INFO] Simple check of index "<< simplebestFitPdfIndex <<std::endl;
  
         mass->setBins(nBinsForMass);
+        mass->setBins(10000,"cache");
+        outputws->import(*mass, RooFit::RecycleConflictNodes());
         RooDataHist dataBinned(Form("roohist_data_mass_%s",catname.c_str()),"data",*mass,*dataFull);
 
         // Save it (also a binned version of the dataset

--- a/Background/test/fTest.cpp
+++ b/Background/test/fTest.cpp
@@ -59,7 +59,7 @@ using namespace boost;
 
 namespace po = program_options;
 bool data_by_fit = false;
-bool BLIND = true;
+bool BLIND = false;
 bool runFtestCheckWithToys=false;
 int mgg_low = 500;
 int mgg_high = 1000;
@@ -926,7 +926,7 @@ desc.add_options()
   ("runFtestCheckWithToys", 									"When running the F-test, use toys to calculate pvals (and make plots) ")
   ("is2011",                                                                                  "Run 2011 config")
   ("is2012",                                                                                  "Run 2012 config")
-  ("unblind",  									        "Dont blind plots")
+  ("runBlind",  									        "Blind plots around the Higgs boson mass")
   ("plotRatio", po::bool_switch(&data_by_fit)->default_value(false), "Plot data / fit instead of data - fit")
   ("isFlashgg",  po::value<int>(&isFlashgg_)->default_value(1),  								    	        "Use Flashgg output ")
   ("isData",  po::value<bool>(&isData_)->default_value(0),  								    	        "Use Data not MC ")
@@ -940,7 +940,7 @@ po::store(po::parse_command_line(argc,argv,desc),vm);
 po::notify(vm); 
 if (vm.count("help")) { cout << desc << endl; exit(1); }
 if (vm.count("is2011")) is2011=true;
-if (vm.count("unblind")) BLIND=false;
+if (vm.count("runBlind")) BLIND=true;
 saveMultiPdf = vm.count("saveMultiPdf");
 
 if (vm.count("verbose")) verbose=true;

--- a/Background/tools/submissionTools.py
+++ b/Background/tools/submissionTools.py
@@ -58,9 +58,10 @@ def writeSubFiles(_opts):
       for cidx in range(_opts['nCats']):
         c = _opts['cats'].split(",")[cidx]
         co = _opts['catOffset']+cidx
-        plotDiff = '--plotDiff' if _opts['plotDiff'] else ''
+        plotRatio = '--plotRatio' if _opts['plotRatio'] else ''
+        unblind = '--unblind' if _opts['unblind'] else ''
         _f.write("if [ $1 -eq %g ]; then\n"%cidx)
-        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotDiff)
+        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio,unblind)
         _f.write("  %s\n"%_cmd)
         _f.write("fi\n")
 
@@ -84,10 +85,11 @@ def writeSubFiles(_opts):
       for cidx in range(_opts['nCats']):
         c = _opts['cats'].split(",")[cidx]
         co = _opts['catOffset']+cidx
-        plotDiff = '--plotDiff' if _opts['plotDiff'] else ''
+        plotRatio = '--plotRatio' if _opts['plotRatio'] else ''
+        unblind = '--unblind' if _opts['unblind'] else ''
         _f = open("%s/%s_%s.sh"%(_jobdir,_executable,c),"w")
         writePreamble(_f)
-        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotDiff)
+        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio, unblind)
         _f.write("%s\n"%_cmd)
         _f.close()
         os.system("chmod 775 %s/%s_%s.sh"%(_jobdir,_executable,c))

--- a/Background/tools/submissionTools.py
+++ b/Background/tools/submissionTools.py
@@ -59,9 +59,9 @@ def writeSubFiles(_opts):
         c = _opts['cats'].split(",")[cidx]
         co = _opts['catOffset']+cidx
         plotRatio = '--plotRatio' if _opts['plotRatio'] else ''
-        unblind = '--unblind' if _opts['unblind'] else ''
+        runBlind = '--runBlind' if _opts['runBlind'] else ''
         _f.write("if [ $1 -eq %g ]; then\n"%cidx)
-        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio,unblind)
+        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio,runBlind)
         _f.write("  %s\n"%_cmd)
         _f.write("fi\n")
 
@@ -86,10 +86,10 @@ def writeSubFiles(_opts):
         c = _opts['cats'].split(",")[cidx]
         co = _opts['catOffset']+cidx
         plotRatio = '--plotRatio' if _opts['plotRatio'] else ''
-        unblind = '--unblind' if _opts['unblind'] else ''
+        runBlind = '--runBlind' if _opts['runBlind'] else ''
         _f = open("%s/%s_%s.sh"%(_jobdir,_executable,c),"w")
         writePreamble(_f)
-        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio, unblind)
+        _cmd = "%s/runBackgroundScripts.sh -i %s -p %s -f %s --ext %s --catOffset %g --intLumi %s --year %s --batch %s --queue %s --sigFile %s --isData --fTest %s %s"%(bwd__,_opts['dataFile'],_opts['procs'],c,_opts['ext'],co,_opts['lumi'],_opts['year'],_opts['batch'],_opts['queue'],_opts['signalFitWSFile'],plotRatio, runBlind)
         _f.write("%s\n"%_cmd)
         _f.close()
         os.system("chmod 775 %s/%s_%s.sh"%(_jobdir,_executable,c))

--- a/Signal/tools/finalModel.py
+++ b/Signal/tools/finalModel.py
@@ -68,7 +68,7 @@ def initialiseXSBR(opt):
     for pm in productionModes: xsbr[pm].append(getXS(SM,MHVar,mh,pm))
     xsbr[decayMode].append(getBR(SM,MHVar,mh,decayMode))
     xsbr['constant'].append(1.)
-    mh += 25
+    mh += 1
   for pm in productionModes: xsbr[pm] = np.asarray(xsbr[pm])
   xsbr[decayMode] = np.asarray(xsbr[decayMode])
   xsbr['constant'] = np.asarray(xsbr['constant'])
@@ -429,6 +429,8 @@ class FinalModel:
   # Function for saving to output workspace
   def save(self,wsout):
     wsout.imp = getattr(wsout,"import")
+    self.xvar.setBins(10000, "cache")  # Optional, for safety
+    wsout.imp(self.xvar, ROOT.RooFit.RecycleConflictNodes())
     wsout.imp(self.Pdfs['final'],ROOT.RooFit.RecycleConflictNodes())
     wsout.imp(self.Functions['final_norm'],ROOT.RooFit.RecycleConflictNodes())
     wsout.imp(self.Functions['final_normThisLumi'],ROOT.RooFit.RecycleConflictNodes())


### PR DESCRIPTION
This PR solves the issue of the inaccurate FFT warning from Combine by enforcing cache bins in all output workspaces. <br>
It also fixes the broken `--plotDiff` option, replaced by `--plotRatio` since the difference plot `data - best_fit` is now the default option. Finally, it introduces the `--unblind` option for the background description, and leaves the blinding window 115-135 around the Higgs 'on' by default.